### PR TITLE
MAINT: updating Node.js version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,5 +11,5 @@ inputs:
     description: "The reference for the current commit"
     required: true
 runs:
-  using: "node12"
+  using: "node16"
   main: "compiled/index.js"


### PR DESCRIPTION
This is to address the deprecation in #18, though it will need a release to have an effect for the users 